### PR TITLE
Add SFTP command to server and site view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+.DS_Store

--- a/src/Server.tsx
+++ b/src/Server.tsx
@@ -164,6 +164,21 @@ const SingleServerView = ({
           }
         />
         <List.Item
+          id="open-in-sftp"
+          key="open-in-sftp"
+          title={`Open SFTP Connection (${sshUser})`}
+          icon={Icon.Terminal}
+          accessoryTitle={`sftp://${sshUser}@${server.ipAddress}`}
+          actions={
+            <ActionPanel>
+              <OpenInBrowserAction
+                title={`SFTP As User ${sshUser}`}
+                url={`sftp://${sshUser}@${server.ipAddress}`}
+              />
+            </ActionPanel>
+          }
+        />
+        <List.Item
           id="open-in-ploi"
           key="open-in-ploi"
           title="Open in ploi.io"

--- a/src/Site.tsx
+++ b/src/Site.tsx
@@ -146,6 +146,21 @@ export const SitesSingleView = ({
               </ActionPanel>
             }
           />
+          <List.Item
+            id="open-in-sftp"
+            key="open-in-sftp"
+            title={`Open SFTP Connection (${site.systemUser})`}
+            icon={Icon.Terminal}
+            accessoryTitle={`sftp://${site.systemUser}@${server.ipAddress}`}
+            actions={
+              <ActionPanel>
+                <OpenInBrowserAction
+                  title={`SFTP As User ${site.systemUser}`}
+                  url={`sftp://${site.systemUser}@${server.ipAddress}`}
+                />
+              </ActionPanel>
+            }
+          />
         </List.Section>
         <List.Section title="Site Information">
           <List.Item
@@ -166,6 +181,7 @@ export const SitesSingleView = ({
             id: "Site ID",
             serverId: "Server ID",
             domain: "Domain",
+            systemUser: "System User",
             webDirectory: "Public Directory",
             projectType: "Project Type",
             zeroDowntimeDeployment: "Zero-downtime Deployments Enabled",


### PR DESCRIPTION
This commit adds SFTP functionality, both on the Server and Site views. It will open an sftp:// link in the same way as the ssh:// links are set up. If you have any software installed that is set as default app for sftp links, it will open that app. This could for example be Cyberduck. 